### PR TITLE
Use package.json dependencies' binaries in Cakefile

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -2,6 +2,9 @@ fs    = require 'fs'
 path  = require 'path'
 exec  = require( 'child_process' ).exec
 
+# Prepend path to package.json dependencies' binaries
+process.env.PATH = "node_modules/.bin:#{process.env.PATH}"
+
 sh = ( command, callback ) ->
 
   exec command, ( error, stdout, stderr ) ->


### PR DESCRIPTION
cake still needs to be installed globally but this solves the
issue for other dependencies. I saw this technique used in
the hubot Makefile. Should fix issue #4
