### PR TITLE
Update package.json for use with node

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "client side",
     "action view"
   ],
-  "main": "./lib/walrus",
+  "main": "./bin/walrus",
   "dependencies": {},
   "devDependencies": {
     "jison"         : "0.3.2",


### PR DESCRIPTION
I was in the process of trying to add the walrus rendering engine to [consolidate.js](https://github.com/kagd/consolidate.js) for easy use within express but kept running into issues where .parse() was undefined. After a bunch of trial and error I discovered that it was because require('walrus') was not actually loading walrus. It wasn't loading walrus because the package.json was not pointing to the compiled file, it was pointing to the working directory.

To test this out locally before accepting this pull request, you can duplicate this issue by creating a simple node app and just call `var walrus = require('walrus')`. This should throw an error, but if you update the `main` path to `bin` instead of `lib`, it will load up correctly.
